### PR TITLE
Implement base attendance management

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -4,14 +4,23 @@ security:
         Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
     # https://symfony.com/doc/current/security.html#loading-the-user-the-user-provider
     providers:
-        users_in_memory: { memory: null }
+        app_user_provider:
+            entity:
+                class: App\Entity\User
+                property: email
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
             lazy: true
-            provider: users_in_memory
+            provider: app_user_provider
+            form_login:
+                login_path: login
+                check_path: login
+            logout:
+                path: logout
+                target: /
 
             # activate different ways to authenticate
             # https://symfony.com/doc/current/security.html#the-firewall
@@ -22,8 +31,10 @@ security:
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
-        # - { path: ^/admin, roles: ROLE_ADMIN }
-        # - { path: ^/profile, roles: ROLE_USER }
+        - { path: ^/admin, roles: ROLE_ADMIN }
+        - { path: ^/seance, roles: ROLE_FORMATEUR }
+        - { path: ^/presence, roles: ROLE_FORMATEUR }
+        - { path: ^/history, roles: ROLE_USER }
 
 when@test:
     security:

--- a/src/Controller/HistoryController.php
+++ b/src/Controller/HistoryController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Controller;
+
+use App\Repository\PresenceRepository;
+use App\Repository\StudentRepository;
+use App\Repository\SeanceRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+class HistoryController extends AbstractController
+{
+    #[IsGranted('ROLE_USER')]
+    #[Route('/history/student/{id}', name: 'history_student')]
+    public function byStudent(PresenceRepository $presenceRepository, StudentRepository $studentRepository, int $id): Response
+    {
+        $student = $studentRepository->find($id);
+        $presences = $presenceRepository->findBy(['student' => $student]);
+        return $this->render('history/student.html.twig', [
+            'student' => $student,
+            'presences' => $presences,
+        ]);
+    }
+
+    #[IsGranted('ROLE_USER')]
+    #[Route('/history/seance/{id}', name: 'history_seance')]
+    public function bySeance(PresenceRepository $presenceRepository, SeanceRepository $seanceRepository, int $id): Response
+    {
+        $seance = $seanceRepository->find($id);
+        $presences = $presenceRepository->findBy(['seance' => $seance]);
+        return $this->render('history/seance.html.twig', [
+            'seance' => $seance,
+            'presences' => $presences,
+        ]);
+    }
+}

--- a/src/Controller/PresenceController.php
+++ b/src/Controller/PresenceController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Presence;
+use App\Repository\SeanceRepository;
+use App\Repository\StudentRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_FORMATEUR')]
+class PresenceController extends AbstractController
+{
+    #[Route('/presence/{seance}', name: 'presence_mark')]
+    public function mark(
+        Request $request,
+        SeanceRepository $seanceRepository,
+        StudentRepository $studentRepository,
+        EntityManagerInterface $em,
+        int $seance
+    ): Response {
+        $seance = $seanceRepository->find($seance);
+        $students = $studentRepository->findAll();
+
+        if ($request->isMethod('POST')) {
+            foreach ($students as $student) {
+                $status = $request->request->get('status_'.$student->getId());
+                if (!$status) {
+                    continue;
+                }
+                $presence = new Presence();
+                $presence->setStudent($student)
+                    ->setSeance($seance)
+                    ->setStatus($status);
+                $em->persist($presence);
+            }
+            $em->flush();
+            return $this->redirectToRoute('seance_index');
+        }
+
+        return $this->render('presence/mark.html.twig', [
+            'students' => $students,
+            'seance' => $seance,
+        ]);
+    }
+}

--- a/src/Controller/SeanceController.php
+++ b/src/Controller/SeanceController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Seance;
+use App\Form\SeanceType;
+use App\Repository\SeanceRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_FORMATEUR')]
+class SeanceController extends AbstractController
+{
+    #[Route('/seance', name: 'seance_index')]
+    public function index(SeanceRepository $repo): Response
+    {
+        $seances = $repo->findBy(['formateur' => $this->getUser()]);
+        return $this->render('seance/index.html.twig', ['seances' => $seances]);
+    }
+
+    #[Route('/seance/new', name: 'seance_new')]
+    public function new(Request $request, EntityManagerInterface $em): Response
+    {
+        $seance = new Seance();
+        $form = $this->createForm(SeanceType::class, $seance);
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            $seance->setFormateur($this->getUser());
+            $em->persist($seance);
+            $em->flush();
+            return $this->redirectToRoute('seance_index');
+        }
+        return $this->render('seance/new.html.twig', ['form' => $form]);
+    }
+}

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
+
+class SecurityController extends AbstractController
+{
+    #[Route('/login', name: 'login')]
+    public function login(AuthenticationUtils $authenticationUtils): Response
+    {
+        $error = $authenticationUtils->getLastAuthenticationError();
+        $lastUsername = $authenticationUtils->getLastUsername();
+
+        return $this->render('security/login.html.twig', [
+            'last_username' => $lastUsername,
+            'error' => $error,
+        ]);
+    }
+
+    #[Route('/logout', name: 'logout')]
+    public function logout(): void
+    {
+        // controller can be blank: it will never be executed!
+    }
+}

--- a/src/Entity/Presence.php
+++ b/src/Entity/Presence.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\PresenceRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ORM\Entity(repositoryClass: PresenceRepository::class)]
+class Presence
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Student::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Student $student = null;
+
+    #[ORM\ManyToOne(targetEntity: Seance::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Seance $seance = null;
+
+    #[ORM\Column(length: 50)]
+    #[Assert\NotBlank]
+    private ?string $status = null; // present/absent/retard
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getStudent(): ?Student
+    {
+        return $this->student;
+    }
+
+    public function setStudent(Student $student): self
+    {
+        $this->student = $student;
+        return $this;
+    }
+
+    public function getSeance(): ?Seance
+    {
+        return $this->seance;
+    }
+
+    public function setSeance(Seance $seance): self
+    {
+        $this->seance = $seance;
+        return $this;
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): self
+    {
+        $this->status = $status;
+        return $this;
+    }
+}

--- a/src/Entity/Seance.php
+++ b/src/Entity/Seance.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\SeanceRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ORM\Entity(repositoryClass: SeanceRepository::class)]
+class Seance
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'datetime')]
+    #[Assert\NotBlank]
+    private ?\DateTimeInterface $date = null;
+
+    #[ORM\Column(length: 255)]
+    #[Assert\NotBlank]
+    private ?string $matiere = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?User $formateur = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getDate(): ?\DateTimeInterface
+    {
+        return $this->date;
+    }
+
+    public function setDate(\DateTimeInterface $date): self
+    {
+        $this->date = $date;
+        return $this;
+    }
+
+    public function getMatiere(): ?string
+    {
+        return $this->matiere;
+    }
+
+    public function setMatiere(string $matiere): self
+    {
+        $this->matiere = $matiere;
+        return $this;
+    }
+
+    public function getFormateur(): ?User
+    {
+        return $this->formateur;
+    }
+
+    public function setFormateur(User $formateur): self
+    {
+        $this->formateur = $formateur;
+        return $this;
+    }
+}

--- a/src/Entity/Student.php
+++ b/src/Entity/Student.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\StudentRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ORM\Entity(repositoryClass: StudentRepository::class)]
+class Student
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    #[Assert\NotBlank]
+    private ?string $firstname = null;
+
+    #[ORM\Column(length: 255)]
+    #[Assert\NotBlank]
+    private ?string $lastname = null;
+
+    #[ORM\Column(length: 180, unique: true)]
+    #[Assert\NotBlank]
+    #[Assert\Email]
+    private ?string $email = null;
+
+    #[ORM\Column(length: 255)]
+    #[Assert\NotBlank]
+    private ?string $promotion = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getFirstname(): ?string
+    {
+        return $this->firstname;
+    }
+
+    public function setFirstname(string $firstname): self
+    {
+        $this->firstname = $firstname;
+        return $this;
+    }
+
+    public function getLastname(): ?string
+    {
+        return $this->lastname;
+    }
+
+    public function setLastname(string $lastname): self
+    {
+        $this->lastname = $lastname;
+        return $this;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): self
+    {
+        $this->email = $email;
+        return $this;
+    }
+
+    public function getPromotion(): ?string
+    {
+        return $this->promotion;
+    }
+
+    public function setPromotion(string $promotion): self
+    {
+        $this->promotion = $promotion;
+        return $this;
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\UserRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ORM\Entity(repositoryClass: UserRepository::class)]
+class User implements UserInterface, PasswordAuthenticatedUserInterface
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 180, unique: true)]
+    #[Assert\NotBlank]
+    #[Assert\Email]
+    private ?string $email = null;
+
+    /**
+     * @var string[]
+     */
+    #[ORM\Column(type: 'json')]
+    private array $roles = [];
+
+    #[ORM\Column]
+    private ?string $password = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $firstname = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $lastname = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): self
+    {
+        $this->email = $email;
+        return $this;
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return (string) $this->email;
+    }
+
+    public function getRoles(): array
+    {
+        $roles = $this->roles;
+        $roles[] = 'ROLE_USER';
+        return array_unique($roles);
+    }
+
+    public function setRoles(array $roles): self
+    {
+        $this->roles = $roles;
+        return $this;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function setPassword(string $password): self
+    {
+        $this->password = $password;
+        return $this;
+    }
+
+    public function eraseCredentials(): void
+    {
+        // If you store any temporary, sensitive data on the user, clear it here
+    }
+
+    public function getFirstname(): ?string
+    {
+        return $this->firstname;
+    }
+
+    public function setFirstname(string $firstname): self
+    {
+        $this->firstname = $firstname;
+        return $this;
+    }
+
+    public function getLastname(): ?string
+    {
+        return $this->lastname;
+    }
+
+    public function setLastname(string $lastname): self
+    {
+        $this->lastname = $lastname;
+        return $this;
+    }
+}
+

--- a/src/Form/SeanceType.php
+++ b/src/Form/SeanceType.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\Seance;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class SeanceType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('date', DateTimeType::class, ['widget' => 'single_text'])
+            ->add('matiere', TextType::class)
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Seance::class,
+        ]);
+    }
+}

--- a/src/Repository/PresenceRepository.php
+++ b/src/Repository/PresenceRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Presence;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Presence>
+ */
+class PresenceRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Presence::class);
+    }
+}

--- a/src/Repository/SeanceRepository.php
+++ b/src/Repository/SeanceRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Seance;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Seance>
+ */
+class SeanceRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Seance::class);
+    }
+}

--- a/src/Repository/StudentRepository.php
+++ b/src/Repository/StudentRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Student;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Student>
+ */
+class StudentRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Student::class);
+    }
+}

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<User>
+ */
+class UserRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, User::class);
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -12,6 +12,13 @@
         {% endblock %}
     </head>
     <body>
+        <nav>
+            {% if app.user %}
+                Connecté en tant que {{ app.user.email }} - <a href="{{ path('logout') }}">Déconnexion</a>
+            {% else %}
+                <a href="{{ path('login') }}">Connexion</a>
+            {% endif %}
+        </nav>
         {% block body %}{% endblock %}
     </body>
 </html>

--- a/templates/history/seance.html.twig
+++ b/templates/history/seance.html.twig
@@ -1,0 +1,11 @@
+{% extends 'base.html.twig' %}
+{% block body %}
+<h1>Présences de la séance {{ seance.date|date('Y-m-d H:i') }}</h1>
+<ul>
+    {% for p in presences %}
+        <li>{{ p.student.firstname }} {{ p.student.lastname }} : {{ p.status }}</li>
+    {% else %}
+        <li>Aucune présence</li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/templates/history/student.html.twig
+++ b/templates/history/student.html.twig
@@ -1,0 +1,11 @@
+{% extends 'base.html.twig' %}
+{% block body %}
+<h1>Historique de {{ student.firstname }} {{ student.lastname }}</h1>
+<ul>
+    {% for p in presences %}
+        <li>{{ p.seance.date|date('Y-m-d H:i') }} - {{ p.seance.matiere }} : {{ p.status }}</li>
+    {% else %}
+        <li>Aucune présence</li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/templates/presence/mark.html.twig
+++ b/templates/presence/mark.html.twig
@@ -1,0 +1,23 @@
+{% extends 'base.html.twig' %}
+{% block body %}
+<h1>Présences pour la séance {{ seance.date|date('Y-m-d H:i') }}</h1>
+<form method="post">
+<table>
+<tr><th>Étudiant</th><th>Statut</th></tr>
+{% for student in students %}
+<tr>
+    <td>{{ student.firstname }} {{ student.lastname }}</td>
+    <td>
+        <select name="status_{{ student.id }}">
+            <option value="">--</option>
+            <option value="present">Présent</option>
+            <option value="absent">Absent</option>
+            <option value="retard">Retard</option>
+        </select>
+    </td>
+</tr>
+{% endfor %}
+</table>
+<button type="submit">Enregistrer</button>
+</form>
+{% endblock %}

--- a/templates/seance/index.html.twig
+++ b/templates/seance/index.html.twig
@@ -1,0 +1,12 @@
+{% extends 'base.html.twig' %}
+{% block body %}
+<h1>Mes séances</h1>
+<ul>
+    {% for seance in seances %}
+        <li>{{ seance.date|date('Y-m-d H:i') }} - {{ seance.matiere }}</li>
+    {% else %}
+        <li>Aucune séance</li>
+    {% endfor %}
+</ul>
+<a href="{{ path('seance_new') }}">Nouvelle séance</a>
+{% endblock %}

--- a/templates/seance/new.html.twig
+++ b/templates/seance/new.html.twig
@@ -1,0 +1,9 @@
+{% extends 'base.html.twig' %}
+{% block body %}
+<h1>Nouvelle séance</h1>
+{{ form_start(form) }}
+    {{ form_row(form.date) }}
+    {{ form_row(form.matiere) }}
+    <button class="btn">Enregistrer</button>
+{{ form_end(form) }}
+{% endblock %}

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -1,0 +1,15 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+<h1>Connexion</h1>
+{% if error %}
+    <div>{{ error.messageKey|trans(error.messageData, 'security') }}</div>
+{% endif %}
+<form action="{{ path('login') }}" method="post">
+    <label for="username">Email:</label>
+    <input type="text" id="username" name="_username" value="{{ last_username }}" />
+    <label for="password">Mot de passe:</label>
+    <input type="password" id="password" name="_password" />
+    <button type="submit">Se connecter</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add entities for users, students, sessions and presence
- configure authentication with login/logout and role-based access
- create controllers and views for sessions, presence marking and history
- improve layout with simple navigation

## Testing
- `composer install --no-interaction --no-scripts`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6881ae49e52c8323834fabeaeb32e025